### PR TITLE
Adding markdown support for fields

### DIFF
--- a/src/main/java/in/ashwanthkumar/slack/webhook/SlackAttachment.java
+++ b/src/main/java/in/ashwanthkumar/slack/webhook/SlackAttachment.java
@@ -31,7 +31,9 @@ public class SlackAttachment {
     private String imageUrl;
     @SerializedName("fields")
     private List<Field> fields = new ArrayList<Field>();
-
+    @SerializedName("mrkdwn_in")
+    private List<String> markdown = new ArrayList<String>();
+    
     public SlackAttachment(String text) {
         text(text);
     }
@@ -122,6 +124,11 @@ public class SlackAttachment {
         return this;
     }
 
+    public SlackAttachment addMarkdownIn(String markdownin) {
+        this.markdown.add(markdownin);
+        return this;
+    }
+    
     public String getText() {
         return text;
     }


### PR DESCRIPTION
As per the documentation: https://api.slack.com/docs/formatting

We need to add explicitly the fields in the markdown in array to allow formatting the fields like the following:

{
    "attachments": [
        {
            "title": "Title",
            "pretext": "Pretext _supports_ mrkdwn",
            "text": "Testing _right now!_",

```
        "mrkdwn_in": ["text", "pretext"]
    }
]
```

}

I have added the `mrkdwn_in` to the json that you send
