### PR TITLE
Added functionality for adding colon to icon/image name

### DIFF
--- a/src/main/java/in/ashwanthkumar/slack/webhook/Slack.java
+++ b/src/main/java/in/ashwanthkumar/slack/webhook/Slack.java
@@ -82,6 +82,15 @@ public class Slack {
      * @param imageOrIcon Icon Image URL or emoji code from http://www.emoji-cheat-sheet.com/
      */
     public Slack icon(String imageOrIcon) {
+        if (imageOrIcon != null && !imageOrIcon.isEmpty()) {
+            if (!imageOrIcon.startsWith(":")) {
+                imageOrIcon = ":" + imageOrIcon;
+            }
+            if (!imageOrIcon.endsWith(":")) {
+                imageOrIcon = imageOrIcon + ":";
+            }
+        }
+
         this.icon = imageOrIcon;
         return this;
     }

--- a/src/test/java/in/ashwanthkumar/slack/webhook/SlackTest.java
+++ b/src/test/java/in/ashwanthkumar/slack/webhook/SlackTest.java
@@ -40,4 +40,26 @@ public class SlackTest {
         new Slack(null);
     }
 
+    @Test
+    public void shouldAddColonToIconName() throws IOException {
+        Slack slack = new Slack("mockUrl", slackService);
+        slack.icon("ghost");
+        ArgumentCaptor<String> iconCaptor = ArgumentCaptor.forClass(String.class);
+        SlackMessage message = new SlackMessage("hello");
+        doNothing().when(slackService).push(anyString(), eq(message), anyString(), iconCaptor.capture(), anyString(), anyString());
+        slack.sendToChannel("test-channel").push(message);
+        assertThat(iconCaptor.getValue(), is(":ghost:"));
+    }
+
+    @Test
+    public void shouldNotAddColonToIconNameIfAlreadyExists() throws IOException {
+        Slack slack = new Slack("mockUrl", slackService);
+        slack.icon(":ghost:");
+        ArgumentCaptor<String> iconCaptor = ArgumentCaptor.forClass(String.class);
+        SlackMessage message = new SlackMessage("hello");
+        doNothing().when(slackService).push(anyString(), eq(message), anyString(), iconCaptor.capture(), anyString(), anyString());
+        slack.sendToChannel("test-channel").push(message);
+        assertThat(iconCaptor.getValue(), is(":ghost:"));
+    }
+
 }


### PR DESCRIPTION
I made a small addon to the existing code. So it adds a colon before and after the image/icon name, if the user forgets to add it. So that you will get the correct icon either you remember to add the colons or not.